### PR TITLE
getCurrentSiteUrl() is deprecated.

### DIFF
--- a/Apex/SignupController.txt
+++ b/Apex/SignupController.txt
@@ -11,7 +11,7 @@ public with sharing class SignupController {
     public User u {get;set;}
     
     public SignupController (ApexPages.StandardController stdController) {
-        siteURL         = Site.getCurrentSiteUrl();
+        siteURL  = Site.getBaseUrl();
         u = (User)stdController.getRecord();
         
     }


### PR DESCRIPTION
getCurrentSiteUrl() is deprecated. This method was replaced by getBaseUrl() in API version 30.0.